### PR TITLE
Add the flash message on the public page layout

### DIFF
--- a/app/views/layouts/public.html.erb
+++ b/app/views/layouts/public.html.erb
@@ -3,7 +3,7 @@
   <head>
     <title>The Future of Conservation</title>
     <%= csrf_meta_tags %>
-    
+
     <link href="https://fonts.googleapis.com/css?family=Quattrocento+Sans:400,400i,700" rel="stylesheet">
     <%= stylesheet_link_tag 'application', media: 'all' %>
     <%= stylesheet_pack_tag 'application' %>
@@ -11,12 +11,13 @@
     <%= javascript_include_tag 'application' %>
     <%= javascript_pack_tag 'application' %>
     <%= javascript_pack_tag 'application-vue' %>
-    
+
     <%= render 'global/favicon' %>
   </head>
 
   <body class="base--public">
     <%= render 'global_public/topbar' %>
+    <%= render 'global_admin/flash_message' %>
 
     <div id="v-app">
       <%= yield %>


### PR DESCRIPTION
Here is the initial work to add the flash message to the public facing page layout. This means that when a user is not logged in and they attempt to take a survey which has been disabled, they will see a meaningful message explaining that this survey is unavailable.