### PR TITLE
Switch to seven rather then five survey agreement options

### DIFF
--- a/app/helpers/responses_helper.rb
+++ b/app/helpers/responses_helper.rb
@@ -1,6 +1,6 @@
 module ResponsesHelper
   def scale_options_for_answers
-    ["Strongly Disagree", "Disagree", "Neutral", "Agree", "Strongly Agree"]
+    ["Strongly Disagree", "Disagree", "Slightly Disagree", "Neutral", "Slightly Agree", "Agree", "Strongly Agree"]
   end
 
   def get_form_field answer_form
@@ -12,7 +12,7 @@ module ResponsesHelper
         field_type = 'radio-buttons'
         options = scale_options_for_answers.to_json
         scale = true
-  
+
       when 'free-text'
         field_type = 'text-input'
         options = ''.to_json

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -44,10 +44,12 @@ class Answer < ApplicationRecord
 
   def value
     case self.raw
-    when "Strongly Disagree"  then -1.0
-    when "Disagree"           then -0.5
-    when "Agree"              then 0.5
-    when "Strongly Agree"     then 1.0
+    when "Strongly Disagree"  then -3
+    when "Disagree"           then -2
+    when "Slightly Disagree"  then -1
+    when "Slightly Agree"     then 1
+    when "Agree"              then 2
+    when "Strongly Agree"     then 3
     else
       0.0
     end


### PR DESCRIPTION
Initial work towards the move from five to seven survey agreement options. Adding the following: 
- "Slightly agree"
- "Slightly disagree"

As options.