### PR TITLE
Fix support page to be go fox facing

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -5,4 +5,13 @@ class Admin::DashboardController < ApplicationController
     @users = User.all
     @total_results = Survey.count
   end
+
+  def support
+  end
+
+  def about_go_fox
+  end
+
+  def legal
+  end
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,5 +1,5 @@
 class StaticPagesController < ApplicationController
-  skip_before_action :authenticate_user!
+  skip_before_action :authenticate_user!, except: [:support]
 
   layout 'public'
 

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,5 +1,5 @@
 class StaticPagesController < ApplicationController
-  skip_before_action :authenticate_user!, except: [:support]
+  skip_before_action :authenticate_user!
 
   layout 'public'
 
@@ -12,12 +12,9 @@ class StaticPagesController < ApplicationController
   def about_debate
   end
 
-  def support
+  def about_go_fox
   end
 
   def legal
-  end
-
-  def about_go_fox
   end
 end

--- a/app/views/admin/dashboard/about_go_fox.html.erb
+++ b/app/views/admin/dashboard/about_go_fox.html.erb
@@ -1,0 +1,27 @@
+<% content_for :title do %>
+  About Go-Fox
+<% end %>
+
+<div class="container content-padding">
+  <div class="flex">
+    <div class="flex-4-fiths">
+      <div class="box--grey-light">
+        <div class="flex-4-fiths gutters content-padding--public">
+          <% t('about_project').each do |item| %>
+            <div class="block--about">
+              <h2><%= item[:title] %></h2>
+
+              <% if item[:content] %>
+                <div><%= item[:content].html_safe %></div>
+              <% end %>
+
+              <% if item[:accordion] %>
+                <%= render partial: 'global_public/accordion', locals: { accordion: item[:accordion] } %>
+              <% end %>
+
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+</div>

--- a/app/views/admin/dashboard/legal.html.erb
+++ b/app/views/admin/dashboard/legal.html.erb
@@ -1,0 +1,27 @@
+<% content_for :title do %>
+  Legal
+<% end %>
+
+<div class="container content-padding">
+  <div class="flex">
+    <div class="flex-4-fiths">
+      <div class="box--grey-light">
+        <div class="flex-4-fiths gutters content-padding--public">
+          <% t('about_project').each do |item| %>
+            <div class="block--about">
+              <h2><%= item[:title] %></h2>
+
+              <% if item[:content] %>
+                <div><%= item[:content].html_safe %></div>
+              <% end %>
+
+              <% if item[:accordion] %>
+                <%= render partial: 'global_public/accordion', locals: { accordion: item[:accordion] } %>
+              <% end %>
+
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+</div>

--- a/app/views/admin/dashboard/support.html.erb
+++ b/app/views/admin/dashboard/support.html.erb
@@ -1,0 +1,27 @@
+<% content_for :title do %>
+  Support
+<% end %>
+
+<div class="container content-padding">
+  <div class="flex">
+    <div class="flex-4-fiths">
+      <div class="box--grey-light">
+        <div class="flex-4-fiths gutters content-padding--public">
+          <% t('about_project').each do |item| %>
+            <div class="block--about">
+              <h2><%= item[:title] %></h2>
+
+              <% if item[:content] %>
+                <div><%= item[:content].html_safe %></div>
+              <% end %>
+
+              <% if item[:accordion] %>
+                <%= render partial: 'global_public/accordion', locals: { accordion: item[:accordion] } %>
+              <% end %>
+
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+</div>

--- a/app/views/global_admin/_nav.html.erb
+++ b/app/views/global_admin/_nav.html.erb
@@ -19,7 +19,13 @@
       <%= link_to "Manage users", admin_users_path, title: 'Manage users', class: 'nav__a' + current_class?(admin_users_path) %>
     </li>
     <li class="nav__li">
-      <%= link_to "Support", support_path, title: 'Support', class: 'nav__a' + current_class?(support_path) %>
+      <%= link_to "Support", admin_support_path, title: 'Support', class: 'nav__a' + current_class?(admin_support_path) %>
+    </li>
+    <li class="nav__li">
+      <%= link_to "About Go-Fox", admin_about_go_fox_path, title: 'About Go-Fox', class: 'nav__a' + current_class?(admin_about_go_fox_path) %>
+    </li>
+    <li class="nav__li">
+      <%= link_to "Legal", admin_legal_path, title: 'Legal', class: 'nav__a' + current_class?(admin_legal_path) %>
     </li>
   </ul>
 <% end %>

--- a/app/views/global_admin/_nav.html.erb
+++ b/app/views/global_admin/_nav.html.erb
@@ -18,5 +18,8 @@
     <li class="nav__li">
       <%= link_to "Manage users", admin_users_path, title: 'Manage users', class: 'nav__a' + current_class?(admin_users_path) %>
     </li>
+    <li class="nav__li">
+      <%= link_to "Support", support_path, title: 'Support', class: 'nav__a' + current_class?(support_path) %>
+    </li>
   </ul>
 <% end %>

--- a/app/views/global_public/_footer.html.erb
+++ b/app/views/global_public/_footer.html.erb
@@ -6,14 +6,14 @@
         <li class="nav__li"><%= link_to 'Home', root_path, title: 'Future of Conservation', class: 'nav__a' %></li>
         <li class="nav__li"><%= link_to 'About the Debate', '#TODO', title: 'About the Debate', class: 'nav__a' %></li>
         <li class="nav__li"><%= link_to 'About the Project', '#TODO', title: 'About the Project', class: 'nav__a' %></li>
-        <li class="nav__li"><%= link_to 'Legal', '#TODO', title: 'Legal', class: 'nav__a' %></li>
+        <li class="nav__li"><%= link_to 'Legal', legal_path, title: 'Legal', class: 'nav__a' %></li>
       </ul>
 
       <%= link_to '', root_path, title: 'Future of Conservation', class: 'logo--foc-white' %>
 
       <div class="footer__login">
         <span>(Log in for GoFox)</span>
-        
+
         <% if user_signed_in? %>
           <%= link_to "Log out", destroy_user_session_path, method: :delete, class: 'button--log-in' %>
         <% else %>

--- a/app/views/global_public/_nav_primary.html.erb
+++ b/app/views/global_public/_nav_primary.html.erb
@@ -22,10 +22,4 @@
     text="About Go-Fox"
     :current-page="<%= is_current_page?(about_go_fox_path) %>">
   </nav-link>
-
-  <nav-link
-    href="<%= legal_path %>"
-    text="Legal"
-    :current-page="<%= is_current_page?(legal_path) %>">
-  </nav-link>
 </nav-burger>

--- a/app/views/global_public/_nav_primary.html.erb
+++ b/app/views/global_public/_nav_primary.html.erb
@@ -24,12 +24,6 @@
   </nav-link>
 
   <nav-link
-    href="<%= support_path %>"
-    text="Support"
-    :current-page="<%= is_current_page?(support_path) %>">
-  </nav-link>
-
-  <nav-link
     href="<%= legal_path %>"
     text="Legal"
     :current-page="<%= is_current_page?(legal_path) %>">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,9 @@ Rails.application.routes.draw do
 
   namespace :admin do
     root to: "dashboard#index"
+    get :support, path: '/admin/support', to: 'dashboard#support'
+    get :about_go_fox, path: '/admin/about_go_fox', to: 'dashboard#about_go_fox'
+    get :legal, path: '/admin/legal', to: 'dashboard#legal'
     resources :users, controller: "users", except: [:new, :create]
     resources :responses, only: [:index]
 


### PR DESCRIPTION
In this PR I have created the admin facing pages for:

`/admin/support`
`/admin/about_go_fox`
`/admin/legal`

These only appear for a logged in user (admin) and are currently filled with the same temporary placeholder text.