### PR TITLE
Show future of conservation banner on results page when master survey

### DIFF
--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -60,7 +60,7 @@ class ResponsesController < ApplicationController
     def resolve_layout
       case action_name
       when "results"
-        "results"
+        "public"
       else
         "application"
       end

--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -5,6 +5,7 @@ class ResponsesController < ApplicationController
   before_action :set_response, only: [:show, :results, :destroy]
   before_action :require_ownership, only: [:show, :destroy]
   before_action :require_survey_unlocked, only: [:new]
+  layout :resolve_layout
 
   def index
     @responses = @survey.responses
@@ -55,6 +56,16 @@ class ResponsesController < ApplicationController
   end
 
   private
+
+    def resolve_layout
+      case action_name
+      when "results"
+        "results"
+      else
+        "application"
+      end
+    end
+
     def require_survey_published
       return if @survey.published?
       redirect_to root_path, notice: "You cannot submit a response for an unpublished survey"

--- a/app/views/responses/results.html.erb
+++ b/app/views/responses/results.html.erb
@@ -1,8 +1,9 @@
 <div class="title-bar flex flex-v-center gutters">
-  <%= link_to survey_responses_path(@survey), title: 'Back to the list of survey responses', class: 'button--back flex flex-v-center flex-1 flex-h-start' do %>
-    <i class="material-icons">arrow_back</i><span>Responses list</span>
+  <% if current_user %>
+    <%= link_to survey_responses_path(@survey), title: 'Back to the list of survey responses', class: 'button--back flex flex-v-center flex-1 flex-h-start' do %>
+      <i class="material-icons">arrow_back</i><span>Responses list</span>
+    <% end %>
   <% end %>
-
   <h1 class="h1--small-uppercase">Results <span class="normal">ID<%= @response.id %></span></h1>
 
   <div class="title-bar--hidden"></div>

--- a/app/views/responses/results.html.erb
+++ b/app/views/responses/results.html.erb
@@ -40,7 +40,7 @@
       </div>
     </div>
   </div>
-  
+
   <div class="flex">
     <div class="flex-2-thirds">
       <div class="block--results">


### PR DESCRIPTION
This is the initial work to display the public layout for the results page for a particular result. This will always show the Future of Conservation banner and logo on the results page.