### PR TITLE
Modify link in topbar to point to the root path rather than the admin root path

### DIFF
--- a/app/views/global_admin/_topbar.html.erb
+++ b/app/views/global_admin/_topbar.html.erb
@@ -1,5 +1,5 @@
 <div class="topbar--admin gutters flex flex-v-center flex-h-between">
-  <%= link_to admin_root_path, title: 'gofox' do %>
+  <%= link_to root_path, title: 'gofox' do %>
     <%= image_tag 'logos/logo-gofox.svg', alt: 'gofox logo', width: '113px', height: '51px' %>
   <% end %>
 


### PR DESCRIPTION
This is the initial work to fix a bug, where an educational user would click on the go-fox logo and it will not direct the user to the right page and will even say that only admins have access to that page. This fixes the problem for all users.