### PR TITLE
Add indication of required questions

### DIFF
--- a/app/javascript/components/pagination/ProgressBar.vue
+++ b/app/javascript/components/pagination/ProgressBar.vue
@@ -2,9 +2,9 @@
   <div class="progress-bar flex flex-column flex-v-center">
     <div class="progress-bar__tooltip" :class="'progress-bar__tooltip-' + page">
       <i class="progress-bar__tooltip-icon"></i>
-      <span>You are {{ remainingPages }} away from finding out your results</span>
+      <span>You are {{ remainingPages }} away from finding out your results. Required questions are marked with *.</span>
     </div>
-    
+
     <span class="progress-bar__icon" :class="'progress-bar__icon-' + page"></span>
     <p class="progress-bar__page-numbers">
       <span class="bold">Page {{ page }}</span> <span class="italic">of</span> <span class="bold">{{ totalPages }}</span>
@@ -32,5 +32,5 @@
         return `${remaining} ${string}`
       }
     }
-  }  
+  }
 </script>

--- a/app/views/responses/_form.html.erb
+++ b/app/views/responses/_form.html.erb
@@ -1,16 +1,26 @@
 <%= form_with(model: [:survey, response], local: true, id: 'form-survey') do |form| %>
 
   <validation-message message="Please complete the questions highlighted below to continue."></validation-message>
-  
+
   <%= form.fields_for :answers do |answer_form| %>
-    
+
     <page-item :index="<%= answer_form.index %>" class="question">
 
       <template slot="formField" slot-scope="props">
         <div class="question__title">
-          <h3><%= answer_form.object.question.text %></h3>
+          <h3>
+            <% question = answer_form.object.question %>
+            <%= question.text %>
+            <% if question.is_a?(Question) %>
+              *
+            <% elsif question.is_a?(DemographicQuestion) %>
+              <% if question.validation == {required: true}.to_json %>
+                *
+              <% end %>
+            <% end %>
+          </h3>
         </div>
-        
+
         <%= get_form_field answer_form %>
 
         <%= answer_form.hidden_field :answerable_type, value: answer_form.object.question.class.name %>


### PR DESCRIPTION
This is the initial work to add an indication of whether a question is required and is achieved through the use of an asterisk character beside the questions which are required.