### PR TITLE
Fix/add backend validations for new survey creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - `rails db:create db:migrate db:seed`
 - `yarn install`
 - `brew install redis`
+- `brew install graphviz`
 
 You'll need to open a separate tab for each of these to run in...
 

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -37,8 +37,10 @@ class Survey < ApplicationRecord
   accepts_nested_attributes_for :customised_questions, allow_destroy: true
 
   validates_uniqueness_of :master, if: :master
-  validates :customised_questions_max_length, inclusion: { in: [0, 1, 2] }
-  validates :customised_questions_options_max_length, inclusion: { in: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] }
+  validates :customised_questions_max_length, inclusion: { in: [0, 1, 2],
+                                                           message: "Only up to 2 customised questions are allowed." }
+  validates :customised_questions_options_max_length, inclusion: { in: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                                                                   message: "Only up to 10 customised question options are allowed." }
 
   def to_param
     uuid

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -37,6 +37,8 @@ class Survey < ApplicationRecord
   accepts_nested_attributes_for :customised_questions, allow_destroy: true
 
   validates_uniqueness_of :master, if: :master
+  validates :customised_questions_max_length, inclusion: { in: [0, 1, 2] }
+  validates :customised_questions_options_max_length, inclusion: { in: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] }
 
   def to_param
     uuid
@@ -55,5 +57,16 @@ class Survey < ApplicationRecord
 
   def self.master_survey
     find_by_master(true)
+  end
+
+  def customised_questions_max_length
+    customised_questions.length
+  end
+
+  def customised_questions_options_max_length
+    options_lengths = customised_questions.map do |cq|
+      cq.options.length
+    end
+    options_lengths.sort.last
   end
 end

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -37,9 +37,9 @@ class Survey < ApplicationRecord
   accepts_nested_attributes_for :customised_questions, allow_destroy: true
 
   validates_uniqueness_of :master, if: :master
-  validates :customised_questions_max_length, inclusion: { in: [0, 1, 2],
+  validates :customised_questions_max_length, inclusion: { in: [nil, 0, 1, 2],
                                                            message: "Only up to 2 customised questions are allowed." }
-  validates :customised_questions_options_max_length, inclusion: { in: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+  validates :customised_questions_options_max_length, inclusion: { in: [nil, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
                                                                    message: "Only up to 10 customised question options are allowed." }
 
   def to_param
@@ -66,6 +66,7 @@ class Survey < ApplicationRecord
   end
 
   def customised_questions_options_max_length
+    return nil if customised_questions.nil?
     options_lengths = customised_questions.map do |cq|
       cq.options.length
     end

--- a/app/views/surveys/_form.html.erb
+++ b/app/views/surveys/_form.html.erb
@@ -64,6 +64,9 @@
       <% end %>
 
       <h4>Customised Questions</h4>
+      <p>
+        A maximum of two customised questions can be added and up to ten options per customised question.
+      </p>
       <hr>
 
       <div class="customised_questions">

--- a/test/controllers/surveys_controller_test.rb
+++ b/test/controllers/surveys_controller_test.rb
@@ -87,6 +87,42 @@ class SurveysControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to survey_url(Survey.last, locale: :en)
   end
 
+  test "can create survey with two custom questions" do
+    sign_in @user
+    assert_difference('Survey.count') do
+      post surveys_url, params: { survey: { name: "My new survey", published: true, user_id: @user.id, customised_questions_attributes: [ {text: "A question?"}, {text: "another question"} ] } }
+    end
+    assert_redirected_to survey_url(Survey.last, locale: :en)
+    assert_equal 2, Survey.last.customised_questions.count
+  end
+  
+  test "can't create survey with more than two custom questions" do
+    sign_in @user
+    assert_difference('Survey.count', 0) do
+      post surveys_url, params: { survey: { name: "My new survey", published: true, user_id: @user.id, customised_questions_attributes: [ {text: "A question?"}, {text: "another question"}, {text: "were either of those actually questions?"} ] } }
+      assert_response :success # not sure why failed validation returns 200 !?
+    end
+  end
+
+  test "can create survey with custom question with 2 options" do
+    sign_in @user
+    assert_difference('Survey.count') do
+      post surveys_url, params: { survey: { name: "My new survey", published: true, user_id: @user.id, customised_questions_attributes: [ {text: "A question?", options_attributes: [ {text: "True"}, {text: "False"} ] } ] } }
+    end
+    assert_redirected_to survey_url(Survey.last, locale: :en)
+    assert_equal 1, Survey.last.customised_questions.count
+    assert_equal 2, Survey.last.customised_questions.last.options.count
+  end
+
+  test "can'y create survey with custom question with 11 options" do
+    sign_in @user
+    assert_difference('Survey.count',0) do
+      post surveys_url, params: { survey: { name: "My new survey", published: true, user_id: @user.id, customised_questions_attributes: [ {text: "How many african swallos does it take to carry a large coconut??",
+options_attributes: [ {text: "0"}, {text: "1"} , {text: "3"}, {text: "3"}, {text: "4"}, {text: "5"}, {text: "6"}, {text: "7"}, {text: "8"}, {text: "9"}, {text: "10"}] } ] } }
+    end
+    assert_response :success # not sure why failed validation returns 200 !?
+  end
+  
   test "should show survey" do
     @survey = create(:survey, user: @user, published: true)
 


### PR DESCRIPTION
This is the initial PR for the backend validation for the customised questions and their options. The limits for these are defined in the Survey model.