### PR TITLE
Fix/hide survey show page from non authenticated users

### DIFF
--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -1,8 +1,7 @@
 class SurveysController < ApplicationController
-  skip_before_action :authenticate_user!, only: [:show]
   before_action :set_survey, only: [:show, :edit, :update, :destroy, :export]
   before_action :set_customisable_questions, only: [:new, :edit, :show, :update]
-  before_action :require_ownership, only: [:edit, :update, :destroy]
+  before_action :require_ownership, only: [:edit, :update, :destroy, :show]
   before_action :require_unlocked, only: [:show, :edit, :update, :destroy, :export]
 
   # GET /surveys

--- a/app/views/surveys/index.html.erb
+++ b/app/views/surveys/index.html.erb
@@ -33,7 +33,7 @@
                   <i class="material-icons">mode_edit</i>Edit
                 <% end %>
 
-                <popup icon="share" title="Share" url="<%= new_survey_response_path(survey) %>"></popup>
+                <popup icon="share" title="Share" url="<%= new_survey_response_url(survey) %>"></popup>
 
                 <%= link_to survey_responses_path(survey), title: 'View survey results', class: 'button--large-chevrons' do %>
                    Responses<i class="material-icons">chevron_right</i><i class="material-icons">chevron_right</i>

--- a/app/views/surveys/index.html.erb
+++ b/app/views/surveys/index.html.erb
@@ -33,7 +33,7 @@
                   <i class="material-icons">mode_edit</i>Edit
                 <% end %>
 
-                <popup icon="share" title="Share" url="<%= survey_url(survey) %>"></popup>
+                <popup icon="share" title="Share" url="<%= new_survey_response_path(survey) %>"></popup>
 
                 <%= link_to survey_responses_path(survey), title: 'View survey results', class: 'button--large-chevrons' do %>
                    Responses<i class="material-icons">chevron_right</i><i class="material-icons">chevron_right</i>


### PR DESCRIPTION
This is the initial PR to hide the survey show page for non authenticated users and will even restrict this page to just the owner of the survey. I have also fixed the survey share link to point to the actual survey rather than the survey show page.