### PR TITLE
Feature/add timestamps to csv export

### DIFF
--- a/lib/modules/csv_exporter.rb
+++ b/lib/modules/csv_exporter.rb
@@ -20,7 +20,7 @@ module CsvExporter
         @@responses.each do |batch|
           batch.each do |response|
             row = []
-            row << response.survey_id << response.created_at << self.format_response_row(response) << self.format_customised_questions(response) << self.format_scores(response)
+            row << response.survey_id << response.created_at << response.language << self.format_response_row(response) << self.format_customised_questions(response) << self.format_scores(response)
             csv << row.flatten
           end
         end
@@ -102,13 +102,14 @@ module CsvExporter
       results = []
       survey_id_header = "Survey ID"
       created_at_header = "Created at"
+      language_header = "Language"
       question_headers = @@questions.pluck(:text).map {|text| text.delete(",")}
       score_headers = ["F1", "F2", "F3"]
       customised_question_headers = ["Customised Question 1: Title", "Customised Question 1: Options", "Customised Question 1: Answer",
                                      "Customised Question 2: Title", "Customised Question 2: Options", "Customised Question 2: Answer",
                                      "Customised Question 3: Title", "Customised Question 3: Options", "Customised Question 3: Answer"]
 
-      results << survey_id_header << created_at_header << question_headers << customised_question_headers << score_headers
+      results << survey_id_header << created_at_header << language_header << question_headers << customised_question_headers << score_headers
       results.flatten
     rescue => e
       Appsignal.send_error(e)

--- a/lib/modules/csv_exporter.rb
+++ b/lib/modules/csv_exporter.rb
@@ -20,7 +20,7 @@ module CsvExporter
         @@responses.each do |batch|
           batch.each do |response|
             row = []
-            row << response.survey_id << response.created_at << response.language << self.format_response_row(response) << self.format_customised_questions(response) << self.format_scores(response)
+            row << response.survey_id << response.created_at << self.format_response_row(response) << self.format_customised_questions(response) << self.format_scores(response) << response.language
             csv << row.flatten
           end
         end
@@ -109,7 +109,7 @@ module CsvExporter
                                      "Customised Question 2: Title", "Customised Question 2: Options", "Customised Question 2: Answer",
                                      "Customised Question 3: Title", "Customised Question 3: Options", "Customised Question 3: Answer"]
 
-      results << survey_id_header << created_at_header << language_header << question_headers << customised_question_headers << score_headers
+      results << survey_id_header << created_at_header << question_headers << customised_question_headers << score_headers << language_header
       results.flatten
     rescue => e
       Appsignal.send_error(e)

--- a/lib/modules/csv_exporter.rb
+++ b/lib/modules/csv_exporter.rb
@@ -24,7 +24,7 @@ module CsvExporter
 
       end
 
-    rescue Exception => e
+    rescue => e
       Appsignal.send_error(e)
     end
 
@@ -40,7 +40,7 @@ module CsvExporter
 
     begin
       Response.where(conditions).find_in_batches(batch_size: @@batch_size)
-    rescue Exception => e
+    rescue => e
       Appsignal.send_error(e)
     end
   end
@@ -48,7 +48,7 @@ module CsvExporter
   def self.format_response_row(response, default=@@default_na)
     begin
       @@questions.map {|question| response.answer_for(question)&.raw_formatted || default}
-    rescue Exception => e
+    rescue => e
       Appsignal.send_error(e)
     end
   end
@@ -58,7 +58,7 @@ module CsvExporter
     begin
       row << (response.f1_score || default) << (response.f2_score || default) << (response.f3_score || default)
       row
-    rescue Exception => e
+    rescue => e
       Appsignal.send_error(e)
     end
   end
@@ -83,7 +83,7 @@ module CsvExporter
       customised_question_row << customised_question_responses_na(customised_question_row.length)
       customised_question_row
 
-    rescue Exception => e
+    rescue => e
       Appsignal.send_error(e)
     end
   end
@@ -97,7 +97,7 @@ module CsvExporter
   def self.create_filepath
     folder = Rails.root.join("public", "csv_exports")
     FileUtils.mkdir_p(folder)
-    folder.join("csv_export_#{DateTime.now.to_i}.csv")
+    folder.join("csv_export_#{DateTime.now.to_s}.csv")
   end
 
   def self.headers
@@ -112,7 +112,7 @@ module CsvExporter
 
       results << survey_id_header << question_headers << customised_question_headers << score_headers
       results.flatten
-    rescue Exception => e
+    rescue => e
       Appsignal.send_error(e)
     end
   end

--- a/lib/modules/csv_exporter.rb
+++ b/lib/modules/csv_exporter.rb
@@ -2,6 +2,8 @@ require 'csv'
 require 'securerandom'
 
 module CsvExporter
+  extend CsvHelpers
+
   @@batch_size = 250
   @@default_na = "n/a"
   @@questions  = Question.all + DemographicQuestion.all
@@ -9,7 +11,7 @@ module CsvExporter
 
   def self.export(survey=nil, from_date=nil, to_date=nil)
     begin
-      filepath  = self.create_filepath
+      filepath  = self.create_filepath("csv_export")
       @@responses = self.find_responses(survey, from_date, to_date)
 
       CSV.open(filepath, "wb", {col_sep: ";"}) do |csv|
@@ -93,12 +95,6 @@ module CsvExporter
     row = []
     (9 - response_length).times { row << 'n/a' }
     row
-  end
-
-  def self.create_filepath
-    folder = Rails.root.join("public", "csv_exports")
-    FileUtils.mkdir_p(folder)
-    folder.join("csv_export_#{DateTime.now.to_s}_#{SecureRandom.urlsafe_base64(5)}.csv")
   end
 
   def self.headers

--- a/lib/modules/csv_helpers.rb
+++ b/lib/modules/csv_helpers.rb
@@ -1,0 +1,7 @@
+module CsvHelpers
+  def create_filepath(filename)
+    folder = Rails.root.join("public", "csv_exports")
+    FileUtils.mkdir_p(folder)
+    folder.join("#{filename}_#{Time.now.strftime("%y-%m-%d_%H-%M-%S")}_#{SecureRandom.urlsafe_base64(5)}.csv")
+  end
+end

--- a/lib/modules/csv_user_exporter.rb
+++ b/lib/modules/csv_user_exporter.rb
@@ -36,6 +36,6 @@ module CsvUserExporter
   def self.create_filepath
     folder = Rails.root.join("public", "csv_exports")
     FileUtils.mkdir_p(folder)
-    folder.join("csv_user_export_#{DateTime.now.to_i}.csv")
+    folder.join("csv_user_export_#{DateTime.now.to_s}.csv")
   end
 end

--- a/lib/modules/csv_user_exporter.rb
+++ b/lib/modules/csv_user_exporter.rb
@@ -1,4 +1,5 @@
 require 'csv'
+require 'securerandom'
 
 module CsvUserExporter
   @@batch_size  = 250
@@ -36,6 +37,6 @@ module CsvUserExporter
   def self.create_filepath
     folder = Rails.root.join("public", "csv_exports")
     FileUtils.mkdir_p(folder)
-    folder.join("csv_user_export_#{DateTime.now.to_s}.csv")
+    folder.join("csv_user_export_#{DateTime.now.to_s}_#{SecureRandom.urlsafe_base64(5)}.csv")
   end
 end

--- a/lib/modules/csv_user_exporter.rb
+++ b/lib/modules/csv_user_exporter.rb
@@ -2,6 +2,8 @@ require 'csv'
 require 'securerandom'
 
 module CsvUserExporter
+  extend CsvHelpers
+
   @@batch_size  = 250
   @@remove_keys = ["encrypted_password", "reset_password_token",
                    "reset_password_sent_at", "remember_created_at"]
@@ -9,7 +11,7 @@ module CsvUserExporter
   @@default_na  = "n/a"
 
   def self.export
-    filepath  = self.create_filepath
+    filepath  = self.create_filepath("csv_user_export")
     users = self.find_users
 
     CSV.open(filepath, "wb", {col_sep: ";"}) do |csv|
@@ -32,11 +34,5 @@ module CsvUserExporter
 
   def self.format_user_row(user, default=@@default_na)
     @@attributes.map{ |attr| user.send(attr) || default }
-  end
-
-  def self.create_filepath
-    folder = Rails.root.join("public", "csv_exports")
-    FileUtils.mkdir_p(folder)
-    folder.join("csv_user_export_#{DateTime.now.to_s}_#{SecureRandom.urlsafe_base64(5)}.csv")
   end
 end


### PR DESCRIPTION
This is the initial work to add timestamps inside the CSV export for the responses as the column after the `Survey ID` column. In addition to this, I have also improved the CSV filenames to include the timestamp of the download including a `securerandom` 5 character string to make the filenames unique. I have also fixed an AppSignal issue to better use the following code:
```
   rescue => e
     Appsignal.send_error(e)
   end
```
Which is more preferable. 

