### PR TITLE
Remove description which is incorrect for the organisational survey creation form field

### DIFF
--- a/app/views/surveys/_organisational_fields.html.erb
+++ b/app/views/surveys/_organisational_fields.html.erb
@@ -109,7 +109,6 @@
       id: 'date_established',
       name: '[settings][date_established]',
       label: 'What year was the group/organisation established? (if known)',
-      description: 'Please give the expected date of the session within which you plan to use the survey results (if known)',
       start_year: 1900,
       end_year: Date.current.year,
       discard_day: true,


### PR DESCRIPTION
This is the initial work to fix a text error on one of the organisational survey creation form fields.