### PR TITLE
Fix to only populate the csv with demographic questions and answers if a super user is exporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,22 @@
+
+# v0.2.3
+
+**Fix CSV exported**
+
+* Remove all of the Demographic Questions from the survey CSV exported when a normal user is exporting
+* Only include those Demographic Questions and their answers when a superuser is exporting the CSV
+
 # v0.2.2
 
 **CSV export update**
 
-* Only show email in CSV output for an admin user *
+* Only show email in CSV output for an admin user
 
 # v0.2.1
 
 **Text Updates**
 
-* Small updates to translated text *
+* Small updates to translated text
 
 # v0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 # v0.2.3
 
-**Fix CSV exported**
+**Fix CSV export**
 
 * Remove all of the Demographic Questions from the survey CSV exported when a normal user is exporting
 * Only include those Demographic Questions and their answers when a superuser is exporting the CSV

--- a/lib/modules/csv_exporter.rb
+++ b/lib/modules/csv_exporter.rb
@@ -7,13 +7,11 @@ module CsvExporter
   @@batch_size    = 250
   @@default_na    = "n/a"
   @@responses     = nil
-  @@skip_dq_text  = "Please provide us with your email address so that we can send you summarised results and keep in contact with you about future work based on this survey. We will not use your address for any other reason."
-  @@dq_skip_id    = DemographicQuestion.find_by(text: @@skip_dq_text).id
   @@questions     = []
 
   def self.export(survey=nil, from_date=nil, to_date=nil, user_id=nil)
     begin
-      dqs = User.find(user_id).admin? ? DemographicQuestion.all : DemographicQuestion.includes(:answers).where.not(answers: { answerable_id: @@dq_skip_id })
+      dqs = User.find(user_id).admin? ? DemographicQuestion.all : []
       @@questions = Question.all + dqs
       filepath  = self.create_filepath("csv_export")
       @@responses = self.find_responses(survey, from_date, to_date)


### PR DESCRIPTION
This PR is a small fix to remove all of the Demographic Questions from the survey CSV exported when a normal user is exporting and to only include those Demographic Questions and their answers when a superuser is exporting the CSV.